### PR TITLE
feat: Make percentage optional in UserTargeting metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.4.3] 2025-01-14
+
+### Changed
+- Make percentage optional in UserTargeting metadata
+
 ## [0.4.2] 2025-01-13
 
 ### Changed

--- a/core/src/main/kotlin/com/c0x12c/featureflag/models/MetadataContent.kt
+++ b/core/src/main/kotlin/com/c0x12c/featureflag/models/MetadataContent.kt
@@ -48,17 +48,24 @@ sealed class MetadataContent {
       // Then check whitelist
       whitelistedUsers[userId]?.let { return it }
 
-      // Check if user is in targetedUserIds
-      if (userId in targetedUserIds) {
-        // If percentage is provided, use percentage-based targeting
-        return if (percentage != null) {
+      // First, check if a percentage-based rollout is configured
+      if (percentage != null) {
+        // If the user is in the targeted list, apply percentage-based targeting
+        return if (userId in targetedUserIds) {
           PercentageMatchingUtil.isTargetedBasedOnPercentage(value = userId, percentage = percentage)
         } else {
-          true // If no percentage specified, enable for all targeted users
+          // User is not in the targeted list, return the default value
+          defaultValue
         }
       }
 
-      return defaultValue
+      // Enable the feature for all users in the targeted list
+      return if (userId in targetedUserIds) {
+        true
+      } else {
+        // User is not targeted, return the default value
+        defaultValue
+      }
     }
   }
 

--- a/core/src/main/kotlin/com/c0x12c/featureflag/models/MetadataContent.kt
+++ b/core/src/main/kotlin/com/c0x12c/featureflag/models/MetadataContent.kt
@@ -48,11 +48,11 @@ sealed class MetadataContent {
       // Then check whitelist
       whitelistedUsers[userId]?.let { return it }
 
-      if (userId not in targetedUserIds) {
+      if (userId !in targetedUserIds) {
         return defaultValue
       }
-      
-      return (percentage == null) or PercentageMatchingUtil.isTargetedBasedOnPercentage(value = userId, percentage = percentage)
+
+      return (percentage == null) || PercentageMatchingUtil.isTargetedBasedOnPercentage(value = userId, percentage = percentage)
     }
   }
 

--- a/core/src/main/kotlin/com/c0x12c/featureflag/models/MetadataContent.kt
+++ b/core/src/main/kotlin/com/c0x12c/featureflag/models/MetadataContent.kt
@@ -48,24 +48,11 @@ sealed class MetadataContent {
       // Then check whitelist
       whitelistedUsers[userId]?.let { return it }
 
-      // First, check if a percentage-based rollout is configured
-      if (percentage != null) {
-        // If the user is in the targeted list, apply percentage-based targeting
-        return if (userId in targetedUserIds) {
-          PercentageMatchingUtil.isTargetedBasedOnPercentage(value = userId, percentage = percentage)
-        } else {
-          // User is not in the targeted list, return the default value
-          defaultValue
-        }
+      if (userId not in targetedUserIds) {
+        return defaultValue
       }
-
-      // Enable the feature for all users in the targeted list
-      return if (userId in targetedUserIds) {
-        true
-      } else {
-        // User is not targeted, return the default value
-        defaultValue
-      }
+      
+      return (percentage == null) or PercentageMatchingUtil.isTargetedBasedOnPercentage(value = userId, percentage = percentage)
     }
   }
 


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

### Why
Currently, the `percentage` parameter in `UserTargeting` is required and always applies percentage-based targeting for users in `targetedUserIds`. However, there are use cases where we only want to target specific users without percentage-based rollout.

### What
- Made `percentage` parameter nullable in `UserTargeting` class
- Updated logic to skip percentage-based targeting when `percentage` is null
- Added tests to verify the new behavior

### Solution
Modified `UserTargeting` class to:
- Change `percentage: Double` to `percentage: Double? = null`
- When `percentage` is null, enable feature for all users in `targetedUserIds`
- Maintain existing priority order: blacklist > whitelist > targetedUsers
- Keep percentage-based targeting when `percentage` is provided

This change simplifies user targeting when percentage-based rollout is not needed, while maintaining all existing functionality.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->

- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Added test cases to verify:
- Feature enabled for all targeted users when percentage is null
- Metadata extraction works correctly with null percentage
- Existing functionality (whitelist/blacklist) works as expected

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/b2e70f6f-0960-423c-bf60-731e1ea0876a" />

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have tested that the feature or bug fix works as expected
- [x] I have included helpful comments, particularly in hard-to-understand areas
- [x] I have added tests that prove my changes are functioning
- [x] New and existing unit tests pass locally with my changes

## Related Issues
https://c0x12c.slack.com/archives/C08DA4U4MLH/p1746778944525979